### PR TITLE
chore: remove unused throttle helper

### DIFF
--- a/src/components/ChatWidget.tsx
+++ b/src/components/ChatWidget.tsx
@@ -18,18 +18,6 @@ interface ChatError {
   retryable: boolean;
 }
 
-// Utility functions
-const throttle = (fn: Function, ms = 50) => {
-  let lastCall = 0;
-  return (...args: any[]) => {
-    const now = performance.now();
-    if (now - lastCall >= ms) {
-      lastCall = now;
-      fn(...args);
-    }
-  };
-};
-
 const generateId = () => Math.random().toString(36).substring(2, 15);
 
 const isMobileDevice = () => {


### PR DESCRIPTION
## Summary
- remove the unused throttle helper from the chat widget component
- tidy the surrounding helper section after removing the dead code

## Testing
- npm run lint *(fails: Missing script "lint")*
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8e241666c8325a2d47dc1988f2f3c