### PR TITLE
Align mobile chat input with drawer bounds

### DIFF
--- a/src/components/ChatWidget.tsx
+++ b/src/components/ChatWidget.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { CHAT_API_ENDPOINT, ChatRequestPayload, ChatResponsePayload } from '../config/chat';
 import useKeyboardInset from './chat/useKeyboardInset';
 import MessageList from './chat/MessageList';
@@ -48,6 +48,7 @@ export default function ChatWidget() {
   const [isComposing, setIsComposing] = useState(false);
   const [error, setError] = useState<ChatError | null>(null);
   const [inputHeight, setInputHeight] = useState(72);
+  const [drawerBounds, setDrawerBounds] = useState({ left: 0, width: 0, right: 0 });
   // chat API hook
   const { sendMessage, isLoading: apiLoading, abort } = useChatApi();
   
@@ -57,6 +58,25 @@ export default function ChatWidget() {
   const fabRef = useRef<HTMLButtonElement>(null);
   const focusTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const liveRegionRef = useRef<HTMLDivElement>(null);
+
+  const updateDrawerBounds = useCallback(() => {
+    if (!drawerRef.current) return;
+
+    const rect = drawerRef.current.getBoundingClientRect();
+    setDrawerBounds(prev => {
+      const next = {
+        left: rect.left,
+        width: rect.width,
+        right: rect.right,
+      };
+
+      if (prev.left === next.left && prev.width === next.width && prev.right === next.right) {
+        return prev;
+      }
+
+      return next;
+    });
+  }, []);
 
   // Helper function to reset textarea height and update input height state
   const resetTextareaHeight = () => {
@@ -123,6 +143,33 @@ export default function ChatWidget() {
     window.addEventListener('resize', updateInputHeight);
     return () => window.removeEventListener('resize', updateInputHeight);
   }, [inputValue, keyboardHeight, isMobile]);
+
+  // Track drawer size/position for aligning mobile input
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleUpdate = throttle(() => updateDrawerBounds(), 100);
+
+    updateDrawerBounds();
+
+    window.addEventListener('resize', handleUpdate);
+    window.addEventListener('orientationchange', handleUpdate);
+    const viewport = window.visualViewport;
+    viewport?.addEventListener('resize', handleUpdate);
+
+    let observer: ResizeObserver | null = null;
+    if (typeof ResizeObserver !== 'undefined' && drawerRef.current) {
+      observer = new ResizeObserver(() => handleUpdate());
+      observer.observe(drawerRef.current);
+    }
+
+    return () => {
+      window.removeEventListener('resize', handleUpdate);
+      window.removeEventListener('orientationchange', handleUpdate);
+      viewport?.removeEventListener('resize', handleUpdate);
+      observer?.disconnect();
+    };
+  }, [isOpen, updateDrawerBounds]);
 
   // orientation handling is inside the hook now
 
@@ -603,6 +650,9 @@ export default function ChatWidget() {
           handleKeyDown={handleKeyDown}
           handleSendMessage={handleSendMessage}
           setIsComposing={setIsComposing}
+          drawerLeft={drawerBounds.left}
+          drawerWidth={drawerBounds.width}
+          drawerRight={drawerBounds.right}
         />
       </div>
     </>

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -14,6 +14,9 @@ interface Props {
   handleKeyDown: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void;
   handleSendMessage: () => Promise<void> | void;
   setIsComposing: (v: boolean) => void;
+  drawerLeft?: number;
+  drawerWidth?: number;
+  drawerRight?: number;
 }
 
 export default function ChatInput({
@@ -30,18 +33,30 @@ export default function ChatInput({
   handleKeyDown,
   handleSendMessage,
   setIsComposing,
+  drawerLeft,
+  drawerWidth,
+  drawerRight,
 }: Props) {
   // Mobile: fixed positioning to stick above keyboard
   // Desktop: sticky positioning within drawer
+  const hasDrawerLeft = typeof drawerLeft === 'number';
+  const hasDrawerRight = typeof drawerRight === 'number';
+  const measuredWidth =
+    hasDrawerLeft && hasDrawerRight
+      ? Math.max(drawerRight - drawerLeft, 0)
+      : drawerWidth;
+  const hasDrawerMeasurements = typeof measuredWidth === 'number' && measuredWidth > 0 && hasDrawerLeft;
   const containerStyle = isMobile
     ? {
         position: 'fixed' as const,
-        left: 0,
-        right: 0,
+        left: hasDrawerMeasurements ? drawerLeft ?? 0 : 0,
+        right: hasDrawerMeasurements ? undefined : 0,
+        width: hasDrawerMeasurements ? measuredWidth : undefined,
         bottom: `calc(${keyboardHeight}px + env(safe-area-inset-bottom, 0px))`,
         zIndex: 60,
         padding: '0.75rem',
         boxShadow: '0 -6px 20px rgba(0,0,0,0.12)',
+        boxSizing: 'border-box' as const,
       }
     : {
         position: 'sticky' as const,


### PR DESCRIPTION
## Summary
- capture the chat drawer bounds with a resize observer and window listeners
- pass the measured geometry to the chat input and align the mobile layout to the drawer
- preserve safe-area and keyboard offsets while adapting to orientation and viewport changes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8e237e584832597a89eaf1e6567b9