### PR TITLE
Fix chat live region announcements

### DIFF
--- a/src/components/ChatWidget.tsx
+++ b/src/components/ChatWidget.tsx
@@ -57,6 +57,7 @@ export default function ChatWidget() {
   const fabRef = useRef<HTMLButtonElement>(null);
   const focusTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const liveRegionRef = useRef<HTMLDivElement>(null);
+  const liveRegionTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   // Helper function to reset textarea height and update input height state
   const resetTextareaHeight = () => {
@@ -381,7 +382,16 @@ export default function ChatWidget() {
       
       // Announce new message to screen readers
       if (liveRegionRef.current) {
+        if (liveRegionTimeoutRef.current) {
+          clearTimeout(liveRegionTimeoutRef.current);
+        }
+
         liveRegionRef.current.textContent = `New message: ${content.slice(0, 120)}`;
+        liveRegionTimeoutRef.current = setTimeout(() => {
+          if (liveRegionRef.current) {
+            liveRegionRef.current.textContent = '';
+          }
+        }, 1000);
       }
       
     } catch (err: any) {
@@ -507,6 +517,9 @@ export default function ChatWidget() {
       if (focusTimeoutRef.current) {
         clearTimeout(focusTimeoutRef.current);
       }
+      if (liveRegionTimeoutRef.current) {
+        clearTimeout(liveRegionTimeoutRef.current);
+      }
     };
   }, []);
 
@@ -579,10 +592,11 @@ export default function ChatWidget() {
         </div>
 
         {/* Messages */}
-        <MessageList 
-          messages={messages} 
-          isLoading={isLoading} 
+        <MessageList
+          messages={messages}
+          isLoading={isLoading}
           messagesEndRef={messagesEndRef}
+          liveRegionRef={liveRegionRef}
           inputHeight={inputHeight}
           keyboardHeight={keyboardHeight}
           isMobile={isMobile}

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -11,18 +11,20 @@ interface Props {
   messages: Message[];
   isLoading: boolean;
   messagesEndRef: React.RefObject<HTMLDivElement>;
+  liveRegionRef: React.RefObject<HTMLDivElement>;
   inputHeight?: number;
   keyboardHeight?: number;
   isMobile?: boolean;
 }
 
-export default function MessageList({ 
-  messages, 
-  isLoading, 
-  messagesEndRef, 
-  inputHeight = 72, 
-  keyboardHeight = 0, 
-  isMobile = false 
+export default function MessageList({
+  messages,
+  isLoading,
+  messagesEndRef,
+  liveRegionRef,
+  inputHeight = 72,
+  keyboardHeight = 0,
+  isMobile = false
 }: Props) {
   // Calculate bottom padding to ensure messages aren't hidden behind the input
   const bottomPadding = isMobile 
@@ -39,7 +41,7 @@ export default function MessageList({
         paddingBottom: bottomPadding
       }}
     >
-      <div aria-live="polite" className="sr-only" id="chat-live" />
+      <div aria-live="polite" className="sr-only" id="chat-live" ref={liveRegionRef} />
 
       {messages.map((message) => (
         <div key={message.id} className={`flex ${message.isUser ? 'justify-end' : 'justify-start'}`}>


### PR DESCRIPTION
## Summary
- pass the chat widget live region ref into the message list so screen readers read the aria-live updates
- clear the live region text shortly after announcements to avoid repeat readings and clean up pending timers on unmount

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8e24010ac8325bda10373f3075d27